### PR TITLE
feat: remove print when using emulator

### DIFF
--- a/gcloud_pubsub.go
+++ b/gcloud_pubsub.go
@@ -302,7 +302,6 @@ func ConnectPubSub(opts ...PubSubOptions) (*PubSub, error) {
 	// Environment variables for gcloud emulator:
 	// https://cloud.google.com/sdk/gcloud/reference/beta/emulators/pubsub/
 	if addr := os.Getenv("PUBSUB_EMULATOR_HOST"); addr != "" {
-		fmt.Println(addr)
 		conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return nil, fmt.Errorf("grpc.Dial: %v", err)


### PR DESCRIPTION

This PR removes an unnecessary print call when using the emulator.